### PR TITLE
Reapply libffi.exp changes

### DIFF
--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -221,6 +221,13 @@ proc libffi-dg-test-1 { target_compile prog do_what extra_tool_flags } {
 	set output_match [lreplace $output_match 1 1 $x]
     }
 
+    if { [ istarget "wasm32-*-*" ] } {
+        # emscripten will get confused if told to build as .exe
+        set exec_suffix ""
+    } else {
+        set exec_suffix ".exe"
+    }
+
     # Set up the compiler flags, based on what we're going to do.
 
     set options [list]
@@ -231,7 +238,7 @@ proc libffi-dg-test-1 { target_compile prog do_what extra_tool_flags } {
 	}
 	"link" {
 	    set compile_type "executable"
-	    set output_file "[file rootname [file tail $prog]].exe"
+	    set output_file "[file rootname [file tail $prog]]$exec_suffix"
 	    # The following line is needed for targets like the i960 where
 	    # the default output file is b.out.  Sigh.
 	}
@@ -240,7 +247,7 @@ proc libffi-dg-test-1 { target_compile prog do_what extra_tool_flags } {
 	    # FIXME: "./" is to cope with "." not being in $PATH.
 	    # Should this be handled elsewhere?
 	    # YES.
-	    set output_file "./[file rootname [file tail $prog]].exe"
+	    set output_file "./[file rootname [file tail $prog]]$exec_suffix"
 	    # This is the only place where we care if an executable was
 	    # created or not.  If it was, dg.exp will try to run it.
 	    remote_file build delete $output_file;
@@ -405,6 +412,12 @@ proc libffi_target_compile { source dest type options } {
 
     if { [string match "arc*-*-linux*" $target_triplet] } {
 	lappend options "libs= -lpthread"
+    }
+
+    # emscripten emits this warning while building the feature test
+    # which causes it to be seen as unsupported.
+    if { [string match "wasm32-*" $target_triplet] } {
+    lappend options "additional_flags=-Wno-unused-command-line-argument"
     }
 
     verbose "options: $options"


### PR DESCRIPTION
It looks like these changes were reverted with merge commit https://github.com/hoodmane/libffi-emscripten/commit/ee5bf802f5d06dc22461acab97d45eb64e3dba5a,
which caused the `libffi.closures` tests to be skipped for Node.