### PR TITLE
Don't build docs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,6 @@ export CHOST="wasm32-unknown-linux" # wasm32-unknown-emscripten
 
 autoreconf -fiv
 emconfigure ./configure --host=$CHOST --prefix=$TARGET --enable-static --disable-shared --disable-dependency-tracking \
-  --disable-builddir --disable-multi-os-directory --disable-raw-api
+  --disable-builddir --disable-multi-os-directory --disable-raw-api --disable-docs
 make install
 cp fficonfig.h target/include/


### PR DESCRIPTION
Works around build issue ``makeinfo: command not found``.