### PR TITLE
Remove function pointer cast emulation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             - target
             - testsuite
 
-  test-firefox:
+  test-selenium-firefox:
     <<: *defaults
     steps:
       - checkout
@@ -113,7 +113,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-chrome:
+  test-selenium-chrome:
     <<: *defaults
     steps:
       - checkout
@@ -130,7 +130,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-firefox-bigint:
+  test-selenium-firefox-bigint:
     <<: *defaults
     steps:
       - checkout
@@ -148,7 +148,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-chrome-bigint:
+  test-selenium-chrome-bigint:
     <<: *defaults
     steps:
       - checkout
@@ -210,17 +210,17 @@ workflows:
           requires:
             - install-emsdk
 
-      - test-firefox:
+      - test-selenium-firefox:
           requires:
             - build-libffi
-      - test-chrome:
+      - test-selenium-chrome:
           requires:
             - build-libffi
 
-      - test-firefox-bigint:
+      - test-selenium-firefox-bigint:
           requires:
             - build-libffi-bigint
-      - test-chrome-bigint:
+      - test-selenium-chrome-bigint:
           requires:
             - build-libffi-bigint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             - target
             - testsuite
 
-  test-selenium-firefox:
+  test-firefox:
     <<: *defaults
     steps:
       - checkout
@@ -113,7 +113,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-selenium-chrome:
+  test-chrome:
     <<: *defaults
     steps:
       - checkout
@@ -130,7 +130,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-selenium-firefox-bigint:
+  test-firefox-bigint:
     <<: *defaults
     steps:
       - checkout
@@ -148,7 +148,7 @@ jobs:
       - store_test_results:
           path: test-results
 
-  test-selenium-chrome-bigint:
+  test-chrome-bigint:
     <<: *defaults
     steps:
       - checkout
@@ -210,17 +210,17 @@ workflows:
           requires:
             - install-emsdk
 
-      - test-selenium-firefox:
+      - test-firefox:
           requires:
             - build-libffi
-      - test-selenium-chrome:
+      - test-chrome:
           requires:
             - build-libffi
 
-      - test-selenium-firefox-bigint:
+      - test-firefox-bigint:
           requires:
             - build-libffi-bigint
-      - test-selenium-chrome-bigint:
+      - test-chrome-bigint:
           requires:
             - build-libffi-bigint
 

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,6 @@ WASM_BIGINT=false
 while [ $# -gt 0 ]; do
   case $1 in
     --enable-wasm-bigint) WASM_BIGINT=true ;;
-    --pyodide-fpcast) PYODIDE_FPCAST=true ;;
     --debug) DEBUG=true ;;
     *) echo "ERROR: Unknown parameter: $1" >&2; exit 1 ;;
   esac
@@ -31,15 +30,9 @@ if [ "$WASM_BIGINT" = "true" ]; then
   # We need to detect WASM_BIGINT support at compile time
   export CFLAGS+=" -DWASM_BIGINT"
 fi
-
-if [ "$PYODIDE_FPCAST" = "true" ]; then
-  export CFLAGS+=" -DPYODIDE_FPCAST"
-fi
-
 if [ "$DEBUG" = "true" ]; then
   export CFLAGS+=" -DDEBUG_F"
 fi
-
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-L$TARGET/lib -O3 -s EXPORTED_FUNCTIONS=['_main','_malloc','_free'] -s ALLOW_TABLE_GROWTH"
 if [ "$WASM_BIGINT" = "true" ]; then

--- a/src/wasm32/ffi.c
+++ b/src/wasm32/ffi.c
@@ -90,19 +90,6 @@
 #define ALIGN_ADDRESS(addr, align) (addr &= (~((align) - 1)))
 #define STACK_ALLOC(stack, size, align) ((stack -= (size)), ALIGN_ADDRESS(stack, align))
 
-// Pyodide needs to redefine this to support fpcast emulation
-#define CALL_FUNC_PTR_DEFAULT(func, args...) \
-  wasmTable.get(func).apply(null, args)
-
-#ifndef CALL_FUNC_PTR
-#if PYODIDE_FPCAST
-#define CALL_FUNC_PTR(func, args...) \
-  CALL_FUNC_PTR_DEFAULT(dyncallInvokeMap[func] || func, args)
-#else
-#define CALL_FUNC_PTR CALL_FUNC_PTR_DEFAULT
-#endif
-#endif
-
 // Most wasm runtimes support at most 1000 Js trampoline args.
 #define MAX_ARGS 1000
 
@@ -358,7 +345,7 @@ ffi_call, (ffi_cif * cif, ffi_fp fn, void *rvalue, void **avalue),
   STACK_ALLOC(cur_stack_ptr, 0, MAX_ALIGN);
   stackRestore(cur_stack_ptr);
   LOG_DEBUG("CALL_FUNC_PTR", fn, args);
-  var result = CALL_FUNC_PTR(fn, args);
+  var result = wasmTable.get(fn).apply(null, args);
   // Put the stack pointer back (we moved it if we made a varargs call)
   stackRestore(orig_stack_ptr);
 
@@ -647,10 +634,10 @@ ffi_prep_closure_loc_helper,
     STACK_ALLOC(cur_ptr, 0, MAX_ALIGN);
     stackRestore(cur_ptr);
     LOG_DEBUG("CALL_CLOSURE",  "closure:", closure, "fptr", CLOSURE__fun(closure), "cif",  CLOSURE__cif(closure));
-    CALL_FUNC_PTR(CLOSURE__fun(closure), [
+    wasmTable.get(CLOSURE__fun(closure))(
         CLOSURE__cif(closure), ret_ptr, args_ptr,
         CLOSURE__user_data(closure)
-    ]);
+    );
     stackRestore(orig_stack_ptr);
 
     // If we aren't supposed to return by argument, figure out what to return.


### PR DESCRIPTION
This reverts commit 593b402 and cbc54da, as it's no longer needed
after PR https://github.com/pyodide/pyodide/pull/2019.