### PR TITLE
Prefer the `__EMSCRIPTEN__` definition over `EMSCRIPTEN`

### DIFF
--- a/src/wasm32/ffitarget.h
+++ b/src/wasm32/ffitarget.h
@@ -44,7 +44,7 @@ typedef enum ffi_abi {
   FFI_WASM32, // "raw", no structures or varargs
   FFI_WASM32_EMSCRIPTEN, // structures, varargs, and split 64-bit params
   FFI_LAST_ABI,
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
   FFI_DEFAULT_ABI = FFI_WASM32_EMSCRIPTEN
 #else
   FFI_DEFAULT_ABI = FFI_WASM32


### PR DESCRIPTION
Since the latter is not defined when building with `-sSTRICT` - see:
https://github.com/emscripten-core/emscripten/blob/84a634167a1cd9e8c47d37a559688153a4ceace6/emcc.py#L887-L890

BTW, looking at this enum, maybe we should also add wasm64 ABI variants? However, I have never tested this with `-sMEMORY64`, so I'm not sure if this would work. The `__wasm64__` definition can be used to guard wasm64-specific code.